### PR TITLE
Add rotation info for network source and add height/width restriction 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 
 GROUP_ID=com.linkedin.android.litr
-VERSION_NAME=1.5.6-SNAPSHOT
+VERSION_NAME=1.5.7-pushd

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -152,7 +152,7 @@ public class MediaTransformer {
                 : transformationOptions;
 
         try {
-            MediaSource mediaSource = new MediaExtractorMediaSource(context, inputUri, options.sourceMediaRange, options.sourceSize, options.restrictToHeight, options.restrictToWidth);
+            MediaSource mediaSource = new MediaExtractorMediaSource(context, inputUri, options.sourceMediaRange, options.sourceSize, options.isNetworkSource, options.restrictToHeight, options.restrictToWidth);
 
             int targetTrackCount = 0;
             for (int track = 0; track < mediaSource.getTrackCount(); track++) {

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -152,7 +152,7 @@ public class MediaTransformer {
                 : transformationOptions;
 
         try {
-            MediaSource mediaSource = new MediaExtractorMediaSource(context, inputUri, options.sourceMediaRange, options.sourceSize, options.isNetworkSource);
+            MediaSource mediaSource = new MediaExtractorMediaSource(context, inputUri, options.sourceMediaRange, options.sourceSize, options.restrictToHeight, options.restrictToWidth);
 
             int targetTrackCount = 0;
             for (int track = 0; track < mediaSource.getTrackCount(); track++) {

--- a/litr/src/main/java/com/linkedin/android/litr/TransformationOptions.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationOptions.java
@@ -37,6 +37,8 @@ public class TransformationOptions {
     public final boolean removeMetadata;
     public final long sourceSize;
     public final boolean isNetworkSource;
+    public final int restrictToHeight;
+    public final int restrictToWidth;
 
     private TransformationOptions(@IntRange(from = GRANULARITY_NONE) int granularity,
                                   @Nullable List<GlFilter> videoFilters,
@@ -45,7 +47,9 @@ public class TransformationOptions {
                                   boolean removeAudio,
                                   boolean removeMetadata,
                                   long sourceSize,
-                                  boolean isNetworkSource) {
+                                  boolean isNetworkSource,
+                                  int restrictToHeight,
+                                  int restrictToWidth) {
         this.granularity = granularity;
         this.videoFilters = videoFilters;
         this.audioFilters = audioFilters;
@@ -54,6 +58,8 @@ public class TransformationOptions {
         this.removeMetadata = removeMetadata;
         this.sourceSize = sourceSize;
         this.isNetworkSource = isNetworkSource;
+        this.restrictToHeight = restrictToHeight;
+        this.restrictToWidth = restrictToWidth;
     }
 
     public static class Builder {
@@ -65,6 +71,8 @@ public class TransformationOptions {
         private boolean removeMetadata;
         private long sourceSize = 0;
         private boolean isNetworkSource = false;
+        private int restrictToHeight = -1;
+        private int restrictToWidth = -1;
 
         @NonNull
         public Builder setGranularity(@IntRange(from = GRANULARITY_NONE) int granularity) {
@@ -110,8 +118,15 @@ public class TransformationOptions {
         }
 
         @NonNull
+        public Builder setDimensionRestriction(int maxHeight, int maxWidth) {
+            this.restrictToHeight = maxHeight;
+            this.restrictToWidth = maxWidth;
+            return this;
+        }
+
+        @NonNull
         public TransformationOptions build() {
-            return new TransformationOptions(granularity, videoFilters, audioFilters, sourceMediaRange, removeAudio, removeMetadata, sourceSize, isNetworkSource);
+            return new TransformationOptions(granularity, videoFilters, audioFilters, sourceMediaRange, removeAudio, removeMetadata, sourceSize, isNetworkSource, restrictToHeight, restrictToWidth);
         }
     }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -65,6 +65,7 @@ public class MediaExtractorMediaSource implements MediaSource {
             Log.e(TAG, "Could not check the dimensions of the video source");
         }
         String rotation = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION);
+        Log.i(TAG, "Video rotation " + rotation);
         if (rotation != null) {
             orientationHint = Integer.parseInt(rotation);
         }
@@ -147,6 +148,7 @@ public class MediaExtractorMediaSource implements MediaSource {
     private void checkHeightRestriction(MediaMetadataRetriever mediaMetadataRetriever, int restrictToHeight, Uri uri) throws MediaSourceException, NumberFormatException {
         if (restrictToHeight > 0) {
             String height = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT);
+            Log.i(TAG, "Video height " + height);
             if (height != null) {
                 if (Integer.parseInt(height) > restrictToHeight) {
                     throw new MediaSourceException(DATA_SOURCE, uri, new IllegalArgumentException("Video height greater than given restriction of " + restrictToHeight));
@@ -158,6 +160,7 @@ public class MediaExtractorMediaSource implements MediaSource {
     private void checkWidthRestriction(MediaMetadataRetriever mediaMetadataRetriever, int restrictToWidth, Uri uri) throws MediaSourceException, NumberFormatException {
         if (restrictToWidth > 0) {
             String width = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH);
+            Log.i(TAG, "Video width " + width);
             if (width != null) {
                 if (Integer.parseInt(width) > restrictToWidth) {
                     throw new MediaSourceException(DATA_SOURCE, uri, new IllegalArgumentException("Video width greater than given restriction of " + restrictToWidth));

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -42,10 +42,10 @@ public class MediaExtractorMediaSource implements MediaSource {
     }
 
     public MediaExtractorMediaSource(@NonNull Context context, @NonNull Uri uri, @NonNull MediaRange mediaRange) throws MediaSourceException {
-        this(context, uri, mediaRange, TranscoderUtils.getSize(context, uri), -1, -1);
+        this(context, uri, mediaRange, TranscoderUtils.getSize(context, uri), false, -1, -1);
     }
 
-    public MediaExtractorMediaSource(@NonNull Context context, @NonNull Uri uri, @NonNull MediaRange mediaRange, long size, int restrictToHeight, int restrictToWidth) throws MediaSourceException {
+    public MediaExtractorMediaSource(@NonNull Context context, @NonNull Uri uri, @NonNull MediaRange mediaRange, long size, boolean isNetworkSource, int restrictToHeight, int restrictToWidth) throws MediaSourceException {
         this.mediaRange = mediaRange;
 
         mediaExtractor = new MediaExtractor();
@@ -53,7 +53,11 @@ public class MediaExtractorMediaSource implements MediaSource {
         try {
             mediaExtractor.setDataSource(context, uri, null);
             mediaMetadataRetriever = new MediaMetadataRetriever();
-            mediaMetadataRetriever.setDataSource(context, uri);
+            if (isNetworkSource) {
+                mediaMetadataRetriever.setDataSource(uri.toString(), null);
+            } else {
+                mediaMetadataRetriever.setDataSource(context, uri);
+            }
         } catch (IOException ex) {
             releaseQuietly(mediaMetadataRetriever);
             throw new MediaSourceException(DATA_SOURCE, uri, ex);

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -22,6 +22,7 @@ import com.linkedin.android.litr.utils.TranscoderUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 
 import static com.linkedin.android.litr.exception.MediaSourceException.Error.DATA_SOURCE;
 
@@ -54,7 +55,7 @@ public class MediaExtractorMediaSource implements MediaSource {
             mediaExtractor.setDataSource(context, uri, null);
             mediaMetadataRetriever = new MediaMetadataRetriever();
             if (isNetworkSource) {
-                mediaMetadataRetriever.setDataSource(uri.toString(), null);
+                mediaMetadataRetriever.setDataSource(uri.toString(), new HashMap<>());
             } else {
                 mediaMetadataRetriever.setDataSource(context, uri);
             }

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -52,7 +52,7 @@ public class MediaExtractorMediaSource implements MediaSource {
         mediaExtractor = new MediaExtractor();
         MediaMetadataRetriever mediaMetadataRetriever = null;
         try {
-            mediaExtractor.setDataSource(context, uri, null);
+            mediaExtractor.setDataSource(context, uri, new HashMap<>());
             mediaMetadataRetriever = new MediaMetadataRetriever();
             if (isNetworkSource) {
                 mediaMetadataRetriever.setDataSource(uri.toString(), new HashMap<>());


### PR DESCRIPTION
- Regardless of whether the source video uri is a url or local uri, use the metadata retriever to get rotation flag
- Add options to specify max height and width on a video for the transformation job and to exit early if it is not in limits

For some reason the snapshot of FFmpeg is failing the download. It seems like they stopped allowing snapshots as it was giving 403.
I just added the zip file in our repo so that it does not try to download it.