### PR TITLE
Rotation flag and options to restrict height/width using source format

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/MarshallingTransformationListener.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MarshallingTransformationListener.java
@@ -140,7 +140,7 @@ class MarshallingTransformationListener {
             Bundle data = message.getData();
             String jobId = data.getString(KEY_JOB_ID);
             if (jobId == null) {
-                throw new IllegalArgumentException("Handler message doesn't contain an id!");
+                Log.e(TAG, "Handler message doesn't contain an id!");
             }
 
             switch (message.what) {

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -177,7 +177,7 @@ public class MediaTransformer {
                         context,
                         outputUri,
                         targetTrackCount,
-                        -1, // set rotation/orientation to 0, will update when we have it as part of video track format later
+                        -1, // set rotation/orientation to -1, will update when we have it as part of video track format later
                         outputFormat);
 
                 int trackCount = mediaSource.getTrackCount();

--- a/litr/src/main/java/com/linkedin/android/litr/TransformationListener.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationListener.java
@@ -8,8 +8,8 @@
 package com.linkedin.android.litr;
 
 import androidx.annotation.FloatRange;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.linkedin.android.litr.analytics.TrackTransformationInfo;
 
 import java.util.List;
@@ -24,31 +24,31 @@ public interface TransformationListener {
      * Transformation started successfully
      * @param id request id
      */
-    void onStarted(@NonNull String id);
+    void onStarted(@Nullable String id);
 
     /**
      * Transformation progress update
      * @param id request id
      * @param progress progress, from 0 to 1, with client specified granularity
      */
-    void onProgress(@NonNull String id, @FloatRange(from = 0, to = 1) float progress);
+    void onProgress(@Nullable String id, @FloatRange(from = 0, to = 1) float progress);
 
     /**
      * Transformation completed
      * @param id request id
      */
-    void onCompleted(@NonNull String id, @Nullable List<TrackTransformationInfo> trackTransformationInfos);
+    void onCompleted(@Nullable String id, @Nullable List<TrackTransformationInfo> trackTransformationInfos);
 
     /**
      * Transformation was cancelled
      * @param id request id
      */
-    void onCancelled(@NonNull String id, @Nullable List<TrackTransformationInfo> trackTransformationInfos);
+    void onCancelled(@Nullable String id, @Nullable List<TrackTransformationInfo> trackTransformationInfos);
 
     /**
      * Transformation error
      * @param id request id
      * @param cause error cause
      */
-    void onError(@NonNull String id, @Nullable Throwable cause, @Nullable List<TrackTransformationInfo> trackTransformationInfos);
+    void onError(@Nullable String id, @Nullable Throwable cause, @Nullable List<TrackTransformationInfo> trackTransformationInfos);
 }

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -52,7 +52,7 @@ public class MediaExtractorMediaSource implements MediaSource {
         mediaExtractor = new MediaExtractor();
         MediaMetadataRetriever mediaMetadataRetriever = null;
         try {
-            mediaExtractor.setDataSource(context, uri, null);
+            mediaExtractor.setDataSource(context, uri, new HashMap<>());
             mediaMetadataRetriever = new MediaMetadataRetriever();
             if (isNetworkSource) {
                 mediaMetadataRetriever.setDataSource(uri.toString(), new HashMap<>());

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
@@ -92,11 +92,21 @@ public class MediaMuxerMediaTarget implements MediaTarget {
         }
     }
 
+    /**
+     * Should be called before starting MediaMuxer.
+     * @param orientationHint - rotation matrix info in degree.
+     */
+    public void setOrientationHint(int orientationHint) {
+        this.mediaMuxer.setOrientationHint(orientationHint);
+    }
+
     private void init(@NonNull MediaMuxer mediaMuxer, @IntRange(from = 1) int trackCount, int orientationHint) throws IllegalArgumentException {
         this.trackCount = trackCount;
 
         this.mediaMuxer = mediaMuxer;
-        this.mediaMuxer.setOrientationHint(orientationHint);
+        if (orientationHint != -1) {
+            this.mediaMuxer.setOrientationHint(orientationHint);
+        }
 
         numberOfTracksToAdd = 0;
         isStarted = false;


### PR DESCRIPTION
Previously in #1 we did the copy of rotation flag from source to target video using a MediaMetadataRetriever but had ssl problems for some reason.

This PR does the same using the source format that is retrieved by doing a range request by the MediaExtractor.