### PR TITLE
A133 transcoding issue due to decoder's block size

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -348,6 +348,26 @@ public class MediaTransformer {
                     );
 
                 }
+
+                if (targetFormat.getString(MediaFormat.KEY_MIME).contains("video")) {
+                    // Video decoder on a133 uses block size of 32 and decodes video's frames with width and height a multiple of 32.
+                    // If we do not use the target format a multiple of 32 the encoder will fail to encode a frame that is upscaled by the decoder.
+                    int videoHeight = targetFormat.getInteger(MediaFormat.KEY_HEIGHT);
+                    int videoWidth = targetFormat.getInteger(MediaFormat.KEY_WIDTH);
+                    int widthToUse = videoWidth;
+                    int heightToUse = videoHeight;
+                    if (videoWidth % 32 != 0) {
+                        widthToUse = videoWidth + (32 - videoWidth % 32);
+                    }
+                    if (videoHeight % 32 != 0) {
+                        heightToUse = videoHeight + (32 - videoHeight % 32);
+                    }
+                    Log.i("viral", "width to use " + widthToUse);
+                    Log.i("viral", "height to use " + heightToUse);
+                    targetFormat.setInteger(MediaFormat.KEY_HEIGHT, heightToUse);
+                    targetFormat.setInteger(MediaFormat.KEY_WIDTH, widthToUse);
+                }
+
                 TrackTransform updatedTrackTransform = new TrackTransform.Builder(trackTransform.getMediaSource(),
                         trackTransform.getSourceTrack(),
                         trackTransform.getMediaTarget())
@@ -359,25 +379,6 @@ public class MediaTransformer {
                         .build();
 
                 trackTransforms.set(trackIndex, updatedTrackTransform);
-            }
-
-            if (targetFormat.getString(MediaFormat.KEY_MIME).contains("video")) {
-                // Video decoder on a133 uses block size of 32 and decodes video's frames with width and height a multiple of 32.
-                // If we do not use the target format a multiple of 32 the encoder will fail to encode a frame that is upscaled by the decoder.
-                int videoHeight = targetFormat.getInteger(MediaFormat.KEY_HEIGHT);
-                int videoWidth = targetFormat.getInteger(MediaFormat.KEY_WIDTH);
-                int widthToUse = videoWidth;
-                int heightToUse = videoHeight;
-                if (videoWidth % 32 != 0) {
-                    widthToUse = videoWidth + (32 - videoWidth % 32);
-                }
-                if (videoHeight % 32 != 0) {
-                    heightToUse = videoHeight + (32 - videoHeight % 32);
-                }
-                Log.i("viral", "width to use " + widthToUse);
-                Log.i("viral", "height to use " + heightToUse);
-                targetFormat.setInteger(MediaFormat.KEY_HEIGHT, heightToUse);
-                targetFormat.setInteger(MediaFormat.KEY_WIDTH, widthToUse);
             }
         }
 

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -362,6 +362,7 @@ public class MediaTransformer {
                     if (videoHeight % 32 != 0) {
                         heightToUse = videoHeight + (32 - videoHeight % 32);
                     }
+                    Log.i(TAG, "Video output format resolution width x height: " + widthToUse + " x " + heightToUse);
                     targetFormat.setInteger(MediaFormat.KEY_HEIGHT, heightToUse);
                     targetFormat.setInteger(MediaFormat.KEY_WIDTH, widthToUse);
                 }

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -360,6 +360,25 @@ public class MediaTransformer {
 
                 trackTransforms.set(trackIndex, updatedTrackTransform);
             }
+
+            if (targetFormat.getString(MediaFormat.KEY_MIME).contains("video")) {
+                // Video decoder on a133 uses block size of 32 and decodes video's frames with width and height a multiple of 32.
+                // If we do not use the target format a multiple of 32 the encoder will fail to encode a frame that is upscaled by the decoder.
+                int videoHeight = targetFormat.getInteger(MediaFormat.KEY_HEIGHT);
+                int videoWidth = targetFormat.getInteger(MediaFormat.KEY_WIDTH);
+                int widthToUse = videoWidth;
+                int heightToUse = videoHeight;
+                if (videoWidth % 32 != 0) {
+                    widthToUse = videoWidth + (32 - videoWidth % 32);
+                }
+                if (videoHeight % 32 != 0) {
+                    heightToUse = videoHeight + (32 - videoHeight % 32);
+                }
+                Log.i("viral", "width to use " + widthToUse);
+                Log.i("viral", "height to use " + heightToUse);
+                targetFormat.setInteger(MediaFormat.KEY_HEIGHT, heightToUse);
+                targetFormat.setInteger(MediaFormat.KEY_WIDTH, widthToUse);
+            }
         }
 
         TransformationJob transformationJob = new TransformationJob(requestId,

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -362,8 +362,6 @@ public class MediaTransformer {
                     if (videoHeight % 32 != 0) {
                         heightToUse = videoHeight + (32 - videoHeight % 32);
                     }
-                    Log.i("viral", "width to use " + widthToUse);
-                    Log.i("viral", "height to use " + heightToUse);
                     targetFormat.setInteger(MediaFormat.KEY_HEIGHT, heightToUse);
                     targetFormat.setInteger(MediaFormat.KEY_WIDTH, widthToUse);
                 }


### PR DESCRIPTION
On A133 there are some video resolutions that would not transcode.
Debugging has revealed the following:
- at some point in transcoding the decoder outputs a format change specifically a increase in width of the video
- after the format changes, all new frames decoded are of the new resolution 
- since the encoder was initialized with the width taken from original video, it can no longer encode frames with the new resolution

Couldn't figure out how to change the encoder format to use the new resolution.
Also couldn't figure out stopping + releasing and restarting the encoder as that makes the decoder and out GL surface for color correction out of sync with the new encoder.

Ultimately,
We know that the decoder is going to change the format midway so we can pre calculate what the decoder's format change is going to be by running an experiment with few different resolution videos.
This reveals that the macro block size that decoder ends up using is 32 and the height and width of the video needs to be a multiple of 32.

This PR makes sure the height and width of the output video is taken as the next multiple of 32.
